### PR TITLE
Add | json to yamls to get around installation errors

### DIFF
--- a/postgres/client/init.sls
+++ b/postgres/client/init.sls
@@ -15,7 +15,7 @@ include:
 # Install PostgreSQL client and libraries
 postgresql-client-libs:
   pkg.installed:
-    - pkgs: {{ pkgs }}
+    - pkgs: {{ pkgs | json }}
   {%- if postgres.use_upstream_repo == true %}
     - refresh: True
     - require:

--- a/postgres/dev/init.sls
+++ b/postgres/dev/init.sls
@@ -6,7 +6,7 @@
   {% if pkgs %}
 install-postgres-dev-packages:
   pkg.installed:
-    - pkgs: {{ pkgs }}
+    - pkgs: {{ pkgs | json }}
     {% if postgres.fromrepo %}
     - fromrepo: {{ postgres.fromrepo }}
     {% endif %}

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -17,7 +17,7 @@ include:
 # Install, configure and start PostgreSQL server
 postgresql-server:
   pkg.installed:
-    - pkgs: {{ pkgs }}
+    - pkgs: {{ pkgs | json }}
 {%- if postgres.use_upstream_repo == true %}
     - refresh: True
     - require:


### PR DESCRIPTION
The new version of Salt dropped support for unicode literals in yaml files, requiring us to update them to use the | json. This is a manual reimplementation of what they've done upstream.