### PR TITLE
Don't call postgresql-service-reload when it doesn't get defined

### DIFF
--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -213,7 +213,7 @@ postgresql-pg_ident:
       - file: postgresql-cluster-prepared
       {%- endif %}
     - watch_in:
-      {%- if grains.os not in ('MacOS',) %}
+      {%- if grains.os not in ('MacOS',) and not postgres.restart_service_on_changes %}
       - module: postgresql-service-reload
       {%- else %}
       - service: postgresql-running

--- a/postgres/server/init.sls
+++ b/postgres/server/init.sls
@@ -284,7 +284,7 @@ postgresql-running:
       - file: postgresql-pg_hba
       - file: postgresql-pg_ident
 
-# Reload the service for changes made to `pg_ident.conf` if restart_service_on_changes is True,
+# Reload the service for changes made to `pg_ident.conf` if restart_service_on_changes is False,
 # except for `MacOS` which is handled by `postgresql-running` above.
 {%- if grains.os not in ('MacOS',) and not postgres.restart_service_on_changes %}
 postgresql-service-reload:


### PR DESCRIPTION
(Hopefully) fixes the error we're currently getting on new salt state.applies:
```
reggie:
    - Cannot extend ID 'postgresql-service-reload' in 'base:postgres.server'. It is not part of the high state.
      This is likely due to a missing include statement or an incorrectly typed ID.
      Ensure that a state with an ID of 'postgresql-service-reload' is available
      in environment 'base' and to SLS 'postgres.server'
```